### PR TITLE
permite que la garra se mueva solo cuando el robot esta detenido

### DIFF
--- a/Robochamp2023_Robot.ino
+++ b/Robochamp2023_Robot.ino
@@ -47,7 +47,7 @@ void loop () {
     bool shoot = bitmask.bitmaskToValue(bitmaskReceived, bitmaskValuesPointer, BUTTON_B);
 
     motor.joystick(joystick, turbo);
-    if (crawButton) craw.toggle();
+    if (crawButton && joystick == 1) craw.toggle();
     if (stopButton) stopExcecution();
     if (shoot) thrower.shoot();
     else thrower.stop();  


### PR DESCRIPTION
Cuando se abre o cierra la garra mientras el robot esta en movimiento, hace que no responda al control mientras que esta se esta abriendo, lo cual permite que se pueda perder el control y este choque, es por eso que agregue que solo se pueda abrir o cerrar la garra cuando el robot esta estatico.